### PR TITLE
Allow ORACLE_ENTERING_FALLBACKS_AMOUNTS to be set in .env

### DIFF
--- a/servers/README.md
+++ b/servers/README.md
@@ -179,6 +179,7 @@ The rest of the parameters are optional. If they are missing they are taken from
 
 - ORACLE_ENTERING_FALLBACKS_AMOUNTS = b'\x02\x04\x06\x08\n'
 
+    Environment value must be provided as a hex string (e.g. `020406080A`).
     See ORACLE_PRICE_DELTA_PCT explanation bellow.
 
 - ORACLE_GATHER_SIGNATURE_TIMEOUT = "60 secs"
@@ -357,7 +358,7 @@ ORACLE_PRICE_DELTA_PCT = 0.05
 ORACLE_PRICE_PUBLISH_BLOCKS = 1
 
 #
-ORACLE_ENTERING_FALLBACKS_AMOUNTS=
+ORACLE_ENTERING_FALLBACKS_AMOUNTS=020406080A
 
 # Timeout used when requesting signatures fom other oracles
 ORACLE_GATHER_SIGNATURE_TIMEOUT = "60 secs"

--- a/servers/common/settings.py
+++ b/servers/common/settings.py
@@ -51,7 +51,7 @@ PROXY_HEADERS = config('PROXY_HEADERS', cast=bool, default=False)
 # Print stack trace of errors, used for development
 ON_ERROR_PRINT_STACK_TRACE = config('ON_ERROR_PRINT_STACK_TRACE', cast=bool, default=False)
 # Swagger app version
-VERSION = "1.3.7.1-beta.6"
+VERSION = "1.3.7.1-beta.7"
 
 # These four are for the gas_price fix. Sometimes the gas_price reaches 20Gwei
 # Used the first time if the gas price exceeds the admitted

--- a/servers/oracle/src/oracle_configuration.py
+++ b/servers/oracle/src/oracle_configuration.py
@@ -9,6 +9,11 @@ from enum import Enum
 
 logger = logging.getLogger(__name__)
 
+
+def parse_bytes_env(key):
+    raw = config(key, cast=str, default='')
+    return bytes.fromhex(raw) if raw else None
+
 OracleTurnConfiguration = typing.NamedTuple("OracleTurnConfiguration",
                                             [("price_delta_pct", int),
                                              ("price_publish_blocks", int),
@@ -166,7 +171,7 @@ class OracleConfiguration(MyCfgdLogger):
             },
             "ORACLE_ENTERING_FALLBACKS_AMOUNTS": {
                 "priority": self.Order.configuration_blockchain_default,
-                "configuration": lambda: config('ORACLE_ENTERING_FALLBACKS_AMOUNTS', cast=bytes),
+                "configuration": lambda: parse_bytes_env('ORACLE_ENTERING_FALLBACKS_AMOUNTS'),
                 "blockchain": lambda p: self._eternal_storage_service.get_bytes(p),
                 "description": "Each int in the ORACLE_ENTERING_FALLBACKS_AMOUNTS sequence is the number of fallbacks that will be allowed to publish next.",
                 "default": b'\x02\x04\x06\x08\n',

--- a/servers/oracle/src/test_oracle_turn.py
+++ b/servers/oracle/src/test_oracle_turn.py
@@ -440,3 +440,9 @@ def test_is_oracle_turn_oracles_publish_before_price_expiration():
         assert is_oracle_turn_aux(oracleTurn,
                                   selected_oracles[i].addr,
                                   block_num_list_for_exp_period[8]) is False
+
+
+def test_parse_bytes_env(monkeypatch):
+    monkeypatch.setenv('ORACLE_ENTERING_FALLBACKS_AMOUNTS', '020406080A')
+    from oracle.src.oracle_configuration import parse_bytes_env
+    assert parse_bytes_env('ORACLE_ENTERING_FALLBACKS_AMOUNTS') == b'\x02\x04\x06\x08\n'


### PR DESCRIPTION
When `starlette.config.Config` tries to convert a string from `.env` using `bytes(value)`, a `TypeError` occurs (_“string argument without an encoding”_). Because the error is caught in `initialize()`, the environment value is discarded and the default or on‑chain value is used.