### PR TITLE
Fixing Fallback Oracle Priority Issue After UNNEED→NEED state cycles

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,0 @@
-# Notes related to the branch purpose
-
-## Fixing Fallback Oracle Priority Issue After UNNEED→NEED state cycles
-
-When the oracle’s conditional publish service reports the **UNNEED** (offline) state, the `PriceFollower` object keeps counting blocks that have passed since the last publication and price change. Because these counters are not cleared, the next transition back to the **NEED** state lets fallback oracles publish before the chosen oracle. After multiple **UNNEED→NEED** states cycles, this causes the fallback method to publish first, which is incorrect.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,5 @@
+# Notes related to the branch purpose
+
+## Fixing Fallback Oracle Priority Issue After UNNEED→NEED state cycles
+
+When the oracle’s conditional publish service reports the **UNNEED** (offline) state, the `PriceFollower` object keeps counting blocks that have passed since the last publication and price change. Because these counters are not cleared, the next transition back to the **NEED** state lets fallback oracles publish before the chosen oracle. After multiple **UNNEED→NEED** states cycles, this causes the fallback method to publish first, which is incorrect.

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 - [x] Remove default params for testnet MOC V3 in conditional parameter thresholds.
 - [x] No gas limit address for testnet as default.
 - [x] Add support for MocMultiCollateralGuard in conditional parameter thresholds.
+- [ ] Fixing Fallback Oracle Priority Issue After **UNNEED→NEED** state cycles.
 - [ ] Update the `moneyonchain-prices-source` dependency to the latest "no beta" version (_It will probably be necessary a new release of this dependency first_).
 
 ____

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@
 - [x] Remove default params for testnet MOC V3 in conditional parameter thresholds.
 - [x] No gas limit address for testnet as default.
 - [x] Add support for MocMultiCollateralGuard in conditional parameter thresholds.
-- [ ] Fixing Fallback Oracle Priority Issue After **UNNEED→NEED** state cycles.
+- [x] Fixing Fallback Oracle Priority Issue After **UNNEED→NEED** state cycles.
 - [ ] Update the `moneyonchain-prices-source` dependency to the latest "no beta" version (_It will probably be necessary a new release of this dependency first_).
 
 ____

--- a/servers/common/services/blockchain.py
+++ b/servers/common/services/blockchain.py
@@ -13,8 +13,8 @@ from web3.exceptions import TransactionNotFound
 
 from common.bg_task_executor import BgTaskExecutor
 from common.helpers import dt_now_at_utc
-#from common.services.contract_factory_service import ContractFactoryService
-#from common.services.gas_limit_service import GasLimitService
+
+
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,6 @@ class BlockChainPK(AnyHttpUrl):
 
 class BlockchainStateLoop(BgTaskExecutor):
     def __init__(self, conf, contract_factory, gas_limit_addr: str):
-    #def __init__(self, conf, contract_factory: ContractFactoryService, gas_limit_addr: str):
         gas_limit_addr_service = None
         if gas_limit_addr:
             try:
@@ -144,7 +143,6 @@ class BlockchainStateLoop(BgTaskExecutor):
 
 class GasCalculator:
     def __init__(self, gas_limit_service):
-    #def __init__(self, gas_limit_service: GasLimitService):
         logger.info('Initializing GasCalculator ...')
         def get(var_name, show_fnc=repr):
             value = getattr(settings, var_name)
@@ -255,8 +253,10 @@ class BlockChain:
         logger.debug(f"+++++++++ get tx ++++++++ {str(account_addr)} - {method}")
         from_addr = parse_addr(str(account_addr))
 
-        nonce = await run_in_executor(lambda: self.W3.eth.getTransactionCount(
-                                                                    from_addr))
+        nonce = await run_in_executor(
+            lambda: self.W3.eth.getTransactionCount(from_addr, "pending")
+        )
+        
         logger.debug(f"Nonce: {nonce}  sender: {from_addr}")
         if gas is None:
             try:
@@ -331,8 +331,6 @@ class BlockChain:
                     await asyncio.sleep(1)  # poll_latency)
 
             receipt = await asyncio.wait_for(run_with_timeout(), timeout=timeout)
-            # receipt = await loop.run_in_executor(None, lambda: W3.eth.waitForTransactionReceipt(txhash, timeout=timeout,
-            #                                                                                    poll_latency=poll_latency))
         else:
             receipt = await run_in_executor(lambda: self.W3.eth.getTransactionReceipt(txhash))
         if not receipt:

--- a/servers/common/services/conditional_publish.py
+++ b/servers/common/services/conditional_publish.py
@@ -308,6 +308,12 @@ class ConditionalPublishServiceBase:
 
     def offline_cfg(self):
         raise NotImplementedError
+    
+    def last_online_block(self):
+        raise NotImplementedError
+
+    def last_offline_block(self):
+        raise NotImplementedError
 
     def max_pub_block(self, blockchain_last_pub_block: int):
         raise NotImplementedError
@@ -343,6 +349,12 @@ class DisabledConditionalPublishService(ConditionalPublishServiceBase):
 
     def offline_cfg(self):
         return False
+    
+    def last_online_block(self):
+        return 0
+    
+    def last_offline_block(self):
+        return 0
 
     def max_pub_block(self, blockchain_last_pub_block: int):
         return blockchain_last_pub_block
@@ -610,7 +622,27 @@ class ConditionalPublishService(ConditionalPublishServiceBase):
         await self.update()
         return self.offline_cfg()
 
+    _last_online_block = 0
+    _last_offline_block = 0
+    _last_offline_cfg = False
+
     def offline_cfg(self):
+        out = False
         if self.is_running:
-            return not self.getConditionActive(self._last_value, self._last_block)
-        return False
+            out = not self.getConditionActive(self._last_value, self._last_block)
+            if self._last_offline_cfg != out:
+                if out:
+                    self._last_offline_block = self._last_block
+                    self.logger.info(f"State change to offline again (block: {self._last_offline_block}).")
+                else:
+                    self._last_online_block = self._last_block
+                    self.logger.info(f"State change to online again (block: {self._last_online_block}).")
+        self._last_offline_cfg = out
+        return out
+
+    def last_online_block(self):
+        return self._last_online_block
+
+    def last_offline_block(self):
+        return self._last_offline_block
+

--- a/servers/common/settings.py
+++ b/servers/common/settings.py
@@ -51,7 +51,7 @@ PROXY_HEADERS = config('PROXY_HEADERS', cast=bool, default=False)
 # Print stack trace of errors, used for development
 ON_ERROR_PRINT_STACK_TRACE = config('ON_ERROR_PRINT_STACK_TRACE', cast=bool, default=False)
 # Swagger app version
-VERSION = "1.3.7.1-beta.26"
+VERSION = "1.3.7.1-beta.27"
 
 # These four are for the gas_price fix. Sometimes the gas_price reaches 20Gwei
 # Used the first time if the gas price exceeds the admitted

--- a/servers/oracle/src/oracle_coin_pair_loop.py
+++ b/servers/oracle/src/oracle_coin_pair_loop.py
@@ -83,7 +83,17 @@ class OracleCoinPairLoop(BgTaskExecutor, MyCfgdLogger):
             return self._conf.ORACLE_COIN_PAIR_LOOP_TASK_INTERVAL
         self.signal.from_blockchain(blockchain_info)
 
-        my_turn, oracle_order = self._oracle_turn.is_oracle_turn(blockchain_info, self._oracle_addr, exchange_price)
+        my_turn, oracle_order = self._oracle_turn.is_oracle_turn(
+            blockchain_info, self._oracle_addr, exchange_price)
+
+        fallback_index = None
+        if my_turn and oracle_order:
+            try:
+                fallback_index = oracle_order.index(self._oracle_addr)
+                # zero means is chosen, 1..x means fallback
+            except ValueError:
+                fallback_index = None
+        
         oracle_order = ' '.join(to_short(addr) for addr in oracle_order)
 
         self.debug(f'prev hash: {blockchain_info.last_pub_block_hash.hex()}')
@@ -100,24 +110,34 @@ class OracleCoinPairLoop(BgTaskExecutor, MyCfgdLogger):
                                                                     self._coin_pair,
                                                                     exchange_price,
                                                                     self._oracle_addr,
-                                                                    blockchain_info.last_pub_block))
+                                                                    blockchain_info.last_pub_block),
+                                                 fallback_index=fallback_index,
+                                                 blockchain_info = blockchain_info)
             if not publish_success:
                 # retry immediately.
                 return 1
         return self._conf.ORACLE_COIN_PAIR_LOOP_TASK_INTERVAL
 
-    async def publish(self, oracles, params: PublishPriceParams):
+    async def publish(self, oracles, params: PublishPriceParams,
+                      fallback_index=None, blockchain_info=None):
+        str_as = ""
+        if fallback_index is not None:
+            # fallback_index, zero means is chosen, 1..x means fallback
+            str_as = " AS CHOSEN" if fallback_index==0 else f" AS FALLBACK #{fallback_index}"
+            str_as_low = " (chosen)" if fallback_index==0 else f" (fallback {fallback_index})"
         message = params.prepare_price_msg()
         signature = crypto.sign_message(hexstr="0x" + message, account=oracle_settings.get_oracle_account())
         self.info(f"GOT MESSAGE params {params} and signature {signature}")
         # send message to all oracles to sign
-        self.debug(f"GATHERING SIGNATURES:"
-                  f"last pub blk {params.last_pub_block}, price: {params.price}")
+        self.info(f"GATHERING SIGNATURES:"
+                  f"last pub blk {params.last_pub_block}, price: {params.price}{str_as_low}")
         sigs = await gather_signatures(oracles, params, message, signature,
                                        timeout=self._conf.ORACLE_GATHER_SIGNATURE_TIMEOUT)
         if len(sigs) < len(oracles) // 2 + 1:
-            self.info(f"Publish: Not enough signatures")
+            self.info(f"Publish: Not enough signatures {len(sigs)}/{len(oracles)}{str_as_low}")
             return False
+        else:
+            self.info(f"Publish: enough signatures {len(sigs)}/{len(oracles)}{str_as_low}")
 
         if settings.DEBUG:
             self.debug(f"GOT SIGS %r and params %r recover %r" %
@@ -126,8 +146,8 @@ class OracleCoinPairLoop(BgTaskExecutor, MyCfgdLogger):
 
         monitor.publish_log("%r : %r publishing price: %r" % (self._coin_pair, self._oracle_addr, params.price))
         try:
-            self.info(f"publishing price: {params.price} SENDING TRANSACTION, "
-                      f"last pub block {params.last_pub_block}, price {params.price}")
+            str_block = f", block {blockchain_info.last_pub_block}" if blockchain_info else ""
+            self.info(f"SENDING TRANSACTION{str_as}, last pub block {params.last_pub_block}, price {params.price}{str_block}")
             tx = await self._cps.publish_price(params.version,
                                                params.coin_pair,
                                                params.price,
@@ -138,11 +158,11 @@ class OracleCoinPairLoop(BgTaskExecutor, MyCfgdLogger):
                                                wait=True,
                                                last_gas_price=await self.bs_loop.gas_calc.get_current())
             if is_error(tx):
-                self.error(f"ERROR PUBLISHING {repr(tx)}")
+                self.error(f"ERROR PUBLISHING{str_as}, txid={repr(tx)}")
                 return False
             self.info("//////////////////////////////////////////////////")
             self.info("//////////////////////////////////////////////////")
-            self.info(f"we {self._oracle_addr_med} --------------------> PRICE PUBLISHED {repr(tx)}")
+            self.info(f"PRICE PUBLISHED{str_as}, txid={repr(tx)}")
             self.info("//////////////////////////////////////////////////")
             self.info("//////////////////////////////////////////////////")
             # Last pub block has changed, force an update of the blockchain info.
@@ -157,9 +177,11 @@ class OracleCoinPairLoop(BgTaskExecutor, MyCfgdLogger):
 
 
 async def gather_signatures(oracles, params: PublishPriceParams, message, my_signature, timeout=10):
+    
     cors = [
         get_signature(oracle, params, message, my_signature, timeout=timeout)
         for oracle in oracles if oracle.addr != params.oracle_addr]
+    
     # sigs = await asyncio.gather(*cors, return_exceptions=True)
     needed = len(oracles) // 2
     sigs = []
@@ -170,12 +192,14 @@ async def gather_signatures(oracles, params: PublishPriceParams, message, my_sig
         if len(sigs) >= needed:
             break
     sigs.append(OracleSignature(params.oracle_addr, my_signature))
+    
     # Sort signatures by addr so the smart contract accept them.
     sorted_sigs = sorted([x for x in sigs if x is not None], key=lambda y: int(y.addr, 16))
     return [x.signature for x in sorted_sigs]
 
 
-async def get_signature(oracle: FullOracleRoundInfo, params: PublishPriceParams, message, my_signature, timeout=10):
+async def get_signature(oracle: FullOracleRoundInfo, params: PublishPriceParams,
+                        message, my_signature, timeout=10):
     x = urllib3.util.parse_url(oracle.internetName)
     target_uri = "%s://%s" % (x.scheme, x.host)
     if not x.port is None:

--- a/servers/oracle/src/oracle_turn.py
+++ b/servers/oracle/src/oracle_turn.py
@@ -31,7 +31,7 @@ class PriceFollower(MyCfgdLogger):
         # We already detected a price change before.
         if self.price_change_pub_block == block_chain_info.last_pub_block and self.price_change_block >= 0:
             diff = block_chain_info.block_num - self.price_change_block
-            self.debug(f"Price changed {diff} blocks ago ({block_chain_info.block_num}-{self.price_change_block}")
+            self.debug(f"Price changed {diff} blocks ago ({block_chain_info.block_num}-{self.price_change_block})")
             return diff
 
         delta = helpers.price_delta(block_chain_info.blockchain_price, exchange_price.price)
@@ -70,7 +70,7 @@ class OracleTurn(MyCfgdLogger):
             return True, self.info("selected chosen " + oracle_addr)
         return self._is_oracle_turn_with_msg(vi, oracle_addr, exchange_price, oracle_addresses)
 
-    # Called byt coin_pair_price_loop
+    # Called by coin_pair_price_loop
     def is_oracle_turn(self, vi: OracleBlockchainInfo, oracle_addr,
                        exchange_price: PriceWithTimestamp):
         
@@ -96,10 +96,6 @@ class OracleTurn(MyCfgdLogger):
         entering_fallback_sequence = self.get_fallback_sequence(conf.entering_fallbacks_amounts,
                                                                 len(vi.selected_oracles))
 
-        self.debug("1 ---> %r" % (vi,))
-        self.debug("1 ---> %r %r" % (oracle_addr, exchange_price))
-        self.debug("1 ---> %r %r" % (oracle_addresses, entering_fallback_sequence))
-
         # WARN if oracles won't get to publish before price expires
         ####################################
         if conf.trigger_valid_publication_blocks < len(entering_fallback_sequence) + 1:
@@ -114,22 +110,36 @@ class OracleTurn(MyCfgdLogger):
                    %r < %r. Fix in configuration." % (vi.valid_price_period_in_blocks,
                                                       conf.trigger_valid_publication_blocks))
 
-        blocks_since_price_change = self.price_follower.price_changed_blocks(conf, vi, exchange_price, self._signal)
+        blocks_since_price_change = self.price_follower.price_changed_blocks(
+            conf, vi, exchange_price, self._signal)
 
-        ####################################
-        start_block_pub_period_before_price_expires = (vi.last_pub_block - conf.trigger_valid_publication_blocks +
-                                                   self._signal.get_valid_price_period(vi.valid_price_period_in_blocks))
+        start_block_pub_period_before_price_expires = (
+            vi.last_pub_block
+            - conf.trigger_valid_publication_blocks
+            + self._signal.get_valid_price_period(
+                vi.valid_price_period_in_blocks)
+        )
+
         self.debug(f"block_num {vi.block_num}  "
                    f"start_block_pub_period_before_price_expires {start_block_pub_period_before_price_expires} "
                    f"trigger_valid_publication_blocks {conf.trigger_valid_publication_blocks}"
                    f"vi.valid_price_period_in_blocks {vi.valid_price_period_in_blocks} "
                    f"f={self._signal.get_valid_price_period(vi.valid_price_period_in_blocks)}")
+        
         if vi.block_num >= start_block_pub_period_before_price_expires:
-           can_I_publish = self.can_oracle_publish(vi.block_num - start_block_pub_period_before_price_expires,
-                                                   oracle_addr, oracle_addresses, entering_fallback_sequence,
-                                                   only_chosen=only_chosen)
-           if can_I_publish:
-               return True, self.debug(f"I'm selected to publish before prices expires")
+            
+            can_I_publish = self.can_oracle_publish(
+                vi.block_num - start_block_pub_period_before_price_expires,
+                oracle_addr,
+                oracle_addresses,
+                entering_fallback_sequence,
+                only_chosen=only_chosen
+            )
+            
+            if can_I_publish:
+                return True, self.debug(
+                    f"I'm selected to publish before prices expires"
+                )
 
         if blocks_since_price_change is None:
             return False, self.debug(f"{oracle_addr} Price didn't change enough.")
@@ -175,15 +185,19 @@ class OracleTurn(MyCfgdLogger):
         # blocks_since_pub_is_allowed and uses it as index in the amount
         # of entering fall backs sequence.
         # Also makes sure the index is within range of the list.
-        condition = ((blocks_since_pub_is_allowed is not None) and
-                     (blocks_since_pub_is_allowed < len(entering_fallback_sequence)))
-        entering_fallback_sequence_index = (blocks_since_pub_is_allowed if condition else
-                                            len(entering_fallback_sequence) - 1)
-        selected_fallbacks = oracle_addresses[1:entering_fallback_sequence[entering_fallback_sequence_index]]
-        self.info(f"FB: bck#:{blocks_since_pub_is_allowed} cur-idx: {entering_fallback_sequence_index} take:{entering_fallback_sequence[entering_fallback_sequence_index]}"
-                  f" seq: {[to_short(str(x)) for x in selected_fallbacks]}  total: {len(oracle_addresses)}")
         
-        is_fallback = oracle_addr in selected_fallbacks
+        condition = (
+            (blocks_since_pub_is_allowed is not None) and
+            (blocks_since_pub_is_allowed < len(entering_fallback_sequence))
+        )
+
+        if condition:
+            entering_fallback_sequence_index = blocks_since_pub_is_allowed
+        else:
+            entering_fallback_sequence_index = len(entering_fallback_sequence) - 1
+
+        selected_fallbacks = oracle_addresses[1:entering_fallback_sequence[entering_fallback_sequence_index]]
+        is_fallback = oracle_addr in selected_fallbacks        
 
         if not is_fallback:
             return False
@@ -191,8 +205,18 @@ class OracleTurn(MyCfgdLogger):
         if only_chosen:
             self.info(f">>> {oracle_addr} is the fallback, but a fallbacks are DISABLED !!!")
             return False
-        
+
+        self.info(
+            f"FB: bck#: {blocks_since_pub_is_allowed} "
+            f"cur-idx: {entering_fallback_sequence_index} "
+            f"take: {entering_fallback_sequence[entering_fallback_sequence_index]} "
+            f"sel: {[to_short(str(x)) for x in selected_fallbacks]} "
+            f"total: {len(oracle_addresses)} "
+            f"seq: {entering_fallback_sequence} "
+            f"con: {condition} "
+        )   
         self.info(f">>> {oracle_addr} is the fallback !!!")
+        
         return True
 
     @staticmethod

--- a/servers/oracle/src/oracle_turn.py
+++ b/servers/oracle/src/oracle_turn.py
@@ -120,6 +120,21 @@ class OracleTurn(MyCfgdLogger):
                 vi.valid_price_period_in_blocks)
         )
 
+        # If the last online or offline block is higher than the start block
+        # of the publication period before the price expires, we set it to that
+        # block number so that we can check if the oracle can publish before
+        # the price expires.
+        # This is to ensure that we are not trying to publish before the price
+        # expires, which could lead to multiple oracles publishing without a price change.
+        last_online_block = self._signal.last_online_block()
+        last_offline_block = self._signal.last_offline_block()
+        
+        if last_online_block > start_block_pub_period_before_price_expires:
+            start_block_pub_period_before_price_expires = last_online_block
+
+        if last_offline_block > start_block_pub_period_before_price_expires:
+            start_block_pub_period_before_price_expires = last_offline_block
+
         self.debug(f"block_num {vi.block_num}  "
                    f"start_block_pub_period_before_price_expires {start_block_pub_period_before_price_expires} "
                    f"trigger_valid_publication_blocks {conf.trigger_valid_publication_blocks}"


### PR DESCRIPTION
When the oracle’s conditional publish service reports the **UNNEED** (offline) state, the `PriceFollower` object keeps counting blocks that have passed since the last publication and price change. Because these counters are not cleared, the next transition back to the **NEED** state lets fallback oracles publish before the chosen oracle. After multiple **UNNEED→NEED** states cycles, this causes the fallback method to publish first, which is incorrect.