### PR TITLE
Add Per-Pair Fallback Overrides

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,9 +1,0 @@
-# Notes related to the branch purpose
-
-## Add Per-Pair Fallback Overrides
-
-* Introduce per-pair fallback overrides by checking for `ORACLE_ENTERING_FALLBACKS_AMOUNTS_<PAIR>` environment variables, falling back to the global value when no override is present.
-
-* Update Oracle turn logic to use these pair-specific configurations when evaluating publishing eligibility.
-
-* Document the new override mechanism and provided an example configuration for setting pair-specific fallback sequences.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,9 @@
+# Notes related to the branch purpose
+
+## Add Per-Pair Fallback Overrides
+
+* Introduce per-pair fallback overrides by checking for `ORACLE_ENTERING_FALLBACKS_AMOUNTS_<PAIR>` environment variables, falling back to the global value when no override is present.
+
+* Update Oracle turn logic to use these pair-specific configurations when evaluating publishing eligibility.
+
+* Document the new override mechanism and provided an example configuration for setting pair-specific fallback sequences.

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 - [x] No gas limit address for testnet as default.
 - [x] Add support for MocMultiCollateralGuard in conditional parameter thresholds.
 - [x] Fixing Fallback Oracle Priority Issue After **UNNEED→NEED** state cycles.
-- [ ] Add Per-Pair Fallback Overrides.
+- [x] Add Per-Pair Fallback Overrides.
 - [ ] Update the `moneyonchain-prices-source` dependency to the latest "no beta" version (_It will probably be necessary a new release of this dependency first_).
 
 ____

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 - [x] No gas limit address for testnet as default.
 - [x] Add support for MocMultiCollateralGuard in conditional parameter thresholds.
 - [x] Fixing Fallback Oracle Priority Issue After **UNNEED→NEED** state cycles.
+- [ ] Add Per-Pair Fallback Overrides.
 - [ ] Update the `moneyonchain-prices-source` dependency to the latest "no beta" version (_It will probably be necessary a new release of this dependency first_).
 
 ____

--- a/servers/README.md
+++ b/servers/README.md
@@ -180,6 +180,9 @@ The rest of the parameters are optional. If they are missing they are taken from
 - ORACLE_ENTERING_FALLBACKS_AMOUNTS = b'\x02\x04\x06\x08\n'
 
     Environment value must be provided as a hex string (e.g. `020406080A`).
+    A coin-pair specific override can be defined with
+    `ORACLE_ENTERING_FALLBACKS_AMOUNTS_<PAIR>` (for example
+    `ORACLE_ENTERING_FALLBACKS_AMOUNTS_BTCUSD`).
     See ORACLE_PRICE_DELTA_PCT explanation bellow.
 
 - ORACLE_GATHER_SIGNATURE_TIMEOUT = "60 secs"

--- a/servers/oracle/src/oracle_configuration.py
+++ b/servers/oracle/src/oracle_configuration.py
@@ -4,16 +4,20 @@ from common.helpers import parseTimeDelta, MyCfgdLogger
 from common.services.blockchain import is_error
 from common.services.contract_factory_service import ContractFactoryService
 from common.settings import config, MULTICALL_ADDR
+from oracle_settings import GET_VAR_COINPAIR
 from decimal import Decimal
 from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 
-def parse_bytes_env(key):
-    raw = config(key, cast=str, default='')
+def parse_bytes(raw):
     return bytes.fromhex(raw) if raw else None
 
+def parse_bytes_env(key):
+    raw = config(key, cast=str, default='')
+    return parse_bytes(raw)
+    
 OracleTurnConfiguration = typing.NamedTuple("OracleTurnConfiguration",
                                             [("price_delta_pct", int),
                                              ("price_publish_blocks", int),
@@ -300,9 +304,27 @@ class OracleConfiguration(MyCfgdLogger):
         version = 1
         return "MOC_ORACLE\\%s\\%s" % (version, param_name)
 
+    def get_entering_fallbacks_amounts(self, coin_pair=None):
+        if coin_pair:
+            override = parse_bytes(
+                GET_VAR_COINPAIR(
+                    'ORACLE_ENTERING_FALLBACKS_AMOUNTS',
+                    coin_pair
+                )
+            )
+            if override:
+                return override
+        return self.ORACLE_ENTERING_FALLBACKS_AMOUNTS
+
+    def get_oracle_turn_conf(self, coin_pair=None):
+        return OracleTurnConfiguration(
+            self.ORACLE_PRICE_DELTA_PCT,
+            self.ORACLE_PRICE_PUBLISH_BLOCKS,
+            self.ORACLE_ENTERING_FALLBACKS_AMOUNTS,
+            self.get_entering_fallbacks_amounts(coin_pair),
+            self.ORACLE_TRIGGER_VALID_PUBLICATION_BLOCKS
+        )
+
     @property
     def oracle_turn_conf(self):
-        return OracleTurnConfiguration(self.ORACLE_PRICE_DELTA_PCT,
-                                       self.ORACLE_PRICE_PUBLISH_BLOCKS,
-                                       self.ORACLE_ENTERING_FALLBACKS_AMOUNTS,
-                                       self.ORACLE_TRIGGER_VALID_PUBLICATION_BLOCKS)
+        return self.get_oracle_turn_conf()

--- a/servers/oracle/src/oracle_settings.py
+++ b/servers/oracle/src/oracle_settings.py
@@ -49,7 +49,15 @@ def GET_VAR_COINPAIR(var, coinpair):
     Get a variable for a coinpair. The variable is defined as:
     {var}_{coinpair}
     """
-    env_var_name = f'{var.upper()}_{coinpair.upper()}'
+    
+    def frmt(s):
+        s = s.strip().upper()
+        s = '_'.join(s.split())
+        for r in "/\-":
+            s = s.replace(r, '_')
+        return s
+
+    env_var_name = f'{frmt(var)}_{frmt(coinpair)}'
     return config_per_chain_id(env_var_name, default="")
 
 def load_exchange_info():

--- a/servers/oracle/src/oracle_turn.py
+++ b/servers/oracle/src/oracle_turn.py
@@ -92,9 +92,10 @@ class OracleTurn(MyCfgdLogger):
         if not self.is_oracle_selected_in_round(vi.selected_oracles, oracle_addr):
             return False, self.info(f"is not {oracle_addr} turn we are not in the current round selected oracles")
 
-        conf = self._conf.oracle_turn_conf
-        entering_fallback_sequence = self.get_fallback_sequence(conf.entering_fallbacks_amounts,
-                                                                len(vi.selected_oracles))
+        conf = self._conf.get_oracle_turn_conf(self._coin_pair)
+        
+        entering_fallback_sequence = self.get_fallback_sequence(
+            conf.entering_fallbacks_amounts, len(vi.selected_oracles))
 
         # WARN if oracles won't get to publish before price expires
         ####################################


### PR DESCRIPTION
* Introduce per-pair fallback overrides by checking for `ORACLE_ENTERING_FALLBACKS_AMOUNTS_<PAIR>` environment variables, falling back to the global value when no override is present.

* Update Oracle turn logic to use these pair-specific configurations when evaluating publishing eligibility.

* Document the new override mechanism and provided an example configuration for setting pair-specific fallback sequences.