### PR TITLE
Accept tasks runner min gas as zero

### DIFF
--- a/servers/common/services/coin_pair_price_service.py
+++ b/servers/common/services/coin_pair_price_service.py
@@ -145,8 +145,9 @@ class TasksRunnerService(BaseCoinPairService):
         return f"tasks available: {tasks_available!r} flags: {tasks_flags!r}"
 
     async def _publish(self, params: PublishTaskParams, v: List[int], r: List[bytes], s: List[bytes], account: BlockchainAccount = None, wait=False, last_gas_price=None):
+        gas = settings.TASKS_RUNNER_MIN_GAS or None
         return await self.coin_pair_execute("runTasks", params.version,
                                                   params.coin_pair.longer(), params.tasks_flags, params.oracle_addr,
                                                   params.last_pub_block, v, r, s, account=account, wait=wait,
                                                  last_gas_price=last_gas_price,
-                                                 gas=settings.TASKS_RUNNER_MIN_GAS)
+                                                 gas=gas)

--- a/servers/common/settings.py
+++ b/servers/common/settings.py
@@ -64,7 +64,7 @@ GAS_PRICE_HARD_LIMIT_MAX = config('GAS_PRICE_HARD_LIMIT_MAX', cast=int, default=
 GAS_PRICE_HARD_LIMIT_MULTIPLIER = config('GAS_PRICE_HARD_LIMIT_MULTIPLIER', cast=int, default=1)  # 1 means no changes
 
 COIN_PAIR_SW_ROUND_GAS_LIMIT = config('COIN_PAIR_SW_ROUND_GAS_LIMIT', cast=int, default=2500000)
-TASKS_RUNNER_MIN_GAS = config('TASKS_RUNNER_MIN_GAS', cast=int, default=200000)
+TASKS_RUNNER_MIN_GAS = config('TASKS_RUNNER_MIN_GAS', cast=int, default=900000)
 
 MOC_PRICE_SOURCES_API_URI = config('MOC_PRICE_SOURCES_API_URI', cast=str, default='http://localhost:7989')
 

--- a/servers/common/settings.py
+++ b/servers/common/settings.py
@@ -64,7 +64,7 @@ GAS_PRICE_HARD_LIMIT_MAX = config('GAS_PRICE_HARD_LIMIT_MAX', cast=int, default=
 GAS_PRICE_HARD_LIMIT_MULTIPLIER = config('GAS_PRICE_HARD_LIMIT_MULTIPLIER', cast=int, default=1)  # 1 means no changes
 
 COIN_PAIR_SW_ROUND_GAS_LIMIT = config('COIN_PAIR_SW_ROUND_GAS_LIMIT', cast=int, default=2500000)
-TASKS_RUNNER_MIN_GAS = config('TASKS_RUNNER_MIN_GAS', cast=int, default=900000)
+TASKS_RUNNER_MIN_GAS = config('TASKS_RUNNER_MIN_GAS', cast=int, default=0)
 
 MOC_PRICE_SOURCES_API_URI = config('MOC_PRICE_SOURCES_API_URI', cast=str, default='http://localhost:7989')
 


### PR DESCRIPTION
Allows calculating the gasLimit on tasks runner dinamically, using estimateGas, by setting the configuration value to 0.
Makes this the default behaviour, setting the default to 0.